### PR TITLE
docker-image-watch: read `RESTART_CMD` from the environment if set

### DIFF
--- a/docker-image-watch
+++ b/docker-image-watch
@@ -16,7 +16,7 @@ CONTAINER_DIFF=${CONTAINER_DIFF:-/usr/local/bin/container-diff}
 CONTAINER_DIFF_TYPES=${CONTAINER_DIFF_TYPES:-apt,file}
 
 AUTOPULL=${AUTOPULL:-0}
-RESTART_CMD=
+RESTART_CMD=${RESTART_CMD:-}
 
 get_auth_token()
 {


### PR DESCRIPTION
Do not always override the `RESTART_CMD`, but read the command from the
environment if it has been set. Otherwise, set it to empty.